### PR TITLE
project1/task1: alternative solutions with semaphores

### DIFF
--- a/src/devices/timer.c
+++ b/src/devices/timer.c
@@ -92,8 +92,15 @@ timer_sleep (int64_t ticks)
   int64_t start = timer_ticks ();
 
   ASSERT (intr_get_level () == INTR_ON);
-  while (timer_elapsed (start) < ticks)
-    thread_yield ();
+  
+  /* 
+  Old implementation
+
+  while (timer_elapsed (start) < ticks) 
+  thread_yield ();
+  */
+  
+  thread_sleep(ticks + start);
 }
 
 /* Sleeps for approximately MS milliseconds.  Interrupts must be
@@ -172,6 +179,8 @@ timer_interrupt (struct intr_frame *args UNUSED)
 {
   ticks++;
   thread_tick ();
+
+  thread_awake(ticks);
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/src/devices/timer.c
+++ b/src/devices/timer.c
@@ -92,15 +92,9 @@ timer_sleep (int64_t ticks)
   int64_t start = timer_ticks ();
 
   ASSERT (intr_get_level () == INTR_ON);
-  
-  /* 
-  Old implementation
 
-  while (timer_elapsed (start) < ticks) 
-  thread_yield ();
-  */
-  
-  thread_sleep(ticks + start);
+  // 🧵 project1/task1
+  thread_sleep (start + ticks);
 }
 
 /* Sleeps for approximately MS milliseconds.  Interrupts must be
@@ -180,7 +174,8 @@ timer_interrupt (struct intr_frame *args UNUSED)
   ticks++;
   thread_tick ();
 
-  thread_awake(ticks);
+  // 🧵 project1/task1 wake up routine
+  thread_awake (ticks);
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/src/lib/kernel/list.h
+++ b/src/lib/kernel/list.h
@@ -49,7 +49,7 @@
    in the C++ STL.  If you're familiar with list<>, you should
    find this easy to use.  However, it should be emphasized that
    these lists do *no* type checking and can't do much other
-   correctness checking.  If you screw up, it will bite you.
+   correctness checking.  If you screw up, it will bite you. D:
 
    Glossary of list terms:
 

--- a/src/threads/Make.vars
+++ b/src/threads/Make.vars
@@ -4,4 +4,4 @@ kernel.bin: DEFINES =
 KERNEL_SUBDIRS = threads devices lib lib/kernel $(TEST_SUBDIRS)
 TEST_SUBDIRS = tests/threads
 GRADING_FILE = $(SRCDIR)/tests/threads/Grading
-SIMULATOR = --bochs
+SIMULATOR = --qemu

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -24,7 +24,10 @@
    that are ready to run but not actually running. */
 static struct list ready_list;
 
-/*  */
+/* 🧵 project1/task1
+   List of all currently-sleeping threads ordered by [wakeup_tick]
+   ascending. Processes in this list are in THREAD_BLOCKED state,
+   waiting to be woken up by the timer interrupt handler. */
 static struct list sleep_list;
 
 /* List of all processes.  Processes are added to this list
@@ -95,8 +98,8 @@ thread_init (void)
   lock_init (&tid_lock);
   list_init (&ready_list);
   list_init (&all_list);
-  
-  /* Initialize sleep list */
+
+  // 🧵 project1/task1
   list_init (&sleep_list);
 
   /* Set up a thread structure for the running thread. */
@@ -123,16 +126,21 @@ thread_start (void)
   sema_down (&idle_started);
 }
 
-/* Compares the wakeup_tick value of two threads to determine their order in the ascending list. */
+/* 🧵 project1/task1
+   Comparator function used by thread_sleep to insert threads into
+   the sleep_list */
 bool
-thread_wakeup_tick_less (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED)
+thread_wakeup_tick_less (const struct list_elem *a_, const struct list_elem *b_,
+                         void *aux UNUSED)
 {
   struct thread *a = list_entry (a_, struct thread, elem);
   struct thread *b = list_entry (b_, struct thread, elem);
   return a->wakeup_tick < b->wakeup_tick;
 }
 
-/* Puts the current thread to sleep until the specified number of ticks has passed. */
+/* 🧵 project1/task1
+   Puts the current thread to sleep until the specified number of ticks
+   has passed. */
 void
 thread_sleep (int64_t ticks)
 {
@@ -145,33 +153,32 @@ thread_sleep (int64_t ticks)
   old_level = intr_disable ();
 
   cur->wakeup_tick = ticks;
-
-  list_insert_ordered (&sleep_list, &cur->elem, thread_wakeup_tick_less, NULL); 
-
+  list_insert_ordered (&sleep_list, &cur->elem, thread_wakeup_tick_less, NULL);
   thread_block ();
 
   intr_set_level (old_level);
 }
 
-/* Wakes up all threads that are scheduled to wake up at or before the specified number of ticks. */
+/* 🧵 project1/task1
+   Wakes up all threads that are scheduled to wake up at or before the
+   specified number of ticks. */
 void
-thread_awake(int64_t ticks)
+thread_awake (int64_t ticks)
 {
-  struct list_elem *elem_t = list_begin(&sleep_list);
+  struct list_elem *te = list_begin (&sleep_list);
   struct thread *t;
 
-  while (elem_t != list_end(&sleep_list)) {
-    t = list_entry(elem_t, struct thread, elem);
+  while (!list_empty (&sleep_list))
+    {
+      te = list_begin (&sleep_list);
+      t = list_entry (te, struct thread, elem);
 
-    if (t->wakeup_tick > ticks) {
-      break;
+      if (t->wakeup_tick > ticks)
+        break;
+
+      list_remove (te);
+      thread_unblock (t);
     }
-
-    struct list_elem *next = list_next(elem_t);
-    list_remove(elem_t);
-    thread_unblock(t);
-    elem_t = next;
-  }
 }
 
 /* Called by the timer interrupt handler at each timer tick.

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -90,6 +90,9 @@ struct thread
     int priority;                       /* Priority. */
     struct list_elem allelem;           /* List element for all threads list. */
 
+    /* The tick to wake up the thread */
+    int64_t wakeup_tick;
+
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /* List element. */
 
@@ -118,6 +121,11 @@ tid_t thread_create (const char *name, int priority, thread_func *, void *);
 
 void thread_block (void);
 void thread_unblock (struct thread *);
+
+/* New implemented functions */
+void thread_sleep (int64_t ticks);
+void thread_awake(int64_t ticks);
+bool thread_wakeup_tick_less (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);
 
 struct thread *thread_current (void);
 tid_t thread_tid (void);

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -89,9 +89,8 @@ struct thread
     uint8_t *stack;                     /* Saved stack pointer. */
     int priority;                       /* Priority. */
     struct list_elem allelem;           /* List element for all threads list. */
-
-    /* The tick to wake up the thread */
-    int64_t wakeup_tick;
+    int64_t wakeup_tick;                /* 🧵 project1/task1
+                                           The tick to wake up the thread */
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /* List element. */
@@ -122,7 +121,8 @@ tid_t thread_create (const char *name, int priority, thread_func *, void *);
 void thread_block (void);
 void thread_unblock (struct thread *);
 
-/* New implemented functions */
+// 🧵 project1/task1 definitions
+
 void thread_sleep (int64_t ticks);
 void thread_awake(int64_t ticks);
 bool thread_wakeup_tick_less (const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -4,6 +4,7 @@
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
+#include "threads/synch.h"
 
 /* States in a thread's life cycle. */
 enum thread_status
@@ -89,9 +90,6 @@ struct thread
     uint8_t *stack;                     /* Saved stack pointer. */
     int priority;                       /* Priority. */
     struct list_elem allelem;           /* List element for all threads list. */
-    int64_t wakeup_tick;                /* 🧵 project1/task1
-                                           The tick to wake up the thread */
-
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /* List element. */
 
@@ -103,6 +101,21 @@ struct thread
     /* Owned by thread.c. */
     unsigned magic;                     /* Detects stack overflow. */
   };
+
+/* 🧵 project1/task1
+   The motivation to create a separate struct for sleeping threads is to
+   avoid cluttering the thread structure with additional fields that are
+   only used when the thread is sleeping.
+
+   Another motivation is that if we directly append the thread struct into
+   the sleep_list then the memory will get corrupted when the thread is
+   appended to the semaphore waiters list. */
+struct sleeping_thread {
+    struct thread *t;             /* The thread to sleep */
+    int64_t wakeup_tick;          /* The tick to wake up the thread */
+    struct semaphore sema;        /* Semaphore to block the thread */
+    struct list_elem elem;        /* List element */
+};
 
 /* If false (default), use round-robin scheduler.
    If true, use multi-level feedback queue scheduler.


### PR DESCRIPTION
The following branch starts from https://github.com/proyectitos-fisi/pintos/pull/1 to implement timer_sleep functionality using semaphores to sleep/wake up threads
